### PR TITLE
feat: Added support for markup default imports and namespace validity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,13 @@ chainLoaderConfiguration(config, {
 
 ### Import as a module
 
-One can easily import an XML component just like any regular JS module.  
+One can easily import an XML component just like any regular JS module using either a default or a named import.  
 Example:
 ```javascript
-import MyActionBar from "./components/my-action-bar.xml";
+// Default import
+import MyActionBar123 from "./components/my-action-bar.xml";
+// Named import
+import { MyActionBar } from "./components/my-action-bar.xml";
 ```
 
 ### Import as plain XML
@@ -149,20 +152,15 @@ Data bindings are supported using MVVM pattern by setting view `bindingContext` 
 
 ### Custom components
 
-Regarding custom components, the method to import one inside XML has changed so that it's identical to importing modules in JavaScript.
+Regarding custom components, they can be used in markup by declaring namespaces.  
+A namespace works just like a named import.
 
-Correct approaches, supposing caller directory path is `app/views/home` and components directory path is `app/components`
+A correct approach, supposing caller directory path is `app/views/home` and components directory path is `app/components`
 ```xml
-<!-- Works -->
 <Page xmlns:myxml="../../components/my-xml-component.xml" xmlns:myjs="../../components/my-js-component">
-</Page>
-
-<!-- Works -->
-<Page xmlns:myxml="~/components/my-xml-component.xml" xmlns:myjs="~/components/my-js-component">
-</Page>
-
-<!-- Does not work! -->
-<Page xmlns:myxml="components/my-xml-component.xml" xmlns:myjs="components/my-js-component">
+  <myjs:MyJsComponent/>
+  <!-- OR -->
+  <myjs:default/><!-- in case module has a default export -->
 </Page>
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This will make sure import will resolve to plain XML string content.
 
 ### Data binding
 
-Data bindings are supported using MVVM pattern by setting view `bindingContext` property on JS side.
+Data bindings are supported using MVVM pattern by setting view's `bindingContext` property on JS side.
 ```xml
 <!-- Property binding -->
 <Page>
@@ -149,6 +149,8 @@ Data bindings are supported using MVVM pattern by setting view `bindingContext` 
   </GridLayout>
 </Page>
 ```
+
+Note: Two-way binding is enabled by default. However, events, sub-properties and expressions that make use of `$value`, `$parent`, or `$parents` callers do not support it.
 
 ### Custom components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nativescript-community/xml-ui-loader",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nativescript-community/xml-ui-loader",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/generator": "^7.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript-community/xml-ui-loader",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A webpack loader that works as an ahead-of-time (AOT) compiler which turns XML content into JavaScript during the build phase.",
   "main": "dist/index.js",
   "files": [

--- a/src/bundle-addons.js
+++ b/src/bundle-addons.js
@@ -62,14 +62,7 @@ global.simpleUI = {
     }
 
     const resolvedModuleName = resolveModuleName(uri, ext);
-    if (resolvedModuleName) {
-      const componentModule = global.loadModule(resolvedModuleName, true);
-      if (componentModule.default) {
-        return componentModule.default.name != null ? {[componentModule.default.name]: componentModule.default} : componentModule.default;
-      }
-      return componentModule;
-    }
-    return null;
+    return resolvedModuleName ? global.loadModule(resolvedModuleName, true) : null;
   },
   notifyViewBindingContextChange(args) {
     const view = args.object;


### PR DESCRIPTION
This update focuses on namespace improvements.

- Namespaces will now support default exports
- XML components can now be loaded using both default and named import (named import should use element name which is filename in pascal case)
- Elements that use prefix outside namespace scope will result in error
- Duplicate namespace declarations are no longer allowed
- Fixed an issue when component name was identical to a {N} component name resulting in reference conflict